### PR TITLE
[RFC] Workaround for SSR

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,6 +1,5 @@
 import { default as React, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
-import c3 from 'c3';
 
 export default class Chart extends React.Component {
   static propTypes = {
@@ -8,6 +7,7 @@ export default class Chart extends React.Component {
   }
 
   componentDidMount() {
+    this.c3 = require('c3');
     this._renderChart();
   }
 
@@ -26,7 +26,7 @@ export default class Chart extends React.Component {
   }
 
   _renderChart() {
-    this.chart = c3.generate({
+    this.chart = this.c3.generate({
       bindto: findDOMNode(this),
       ...this.props.config,
     });


### PR DESCRIPTION
## Problem

In my isomorphic project, there is an error when I try to use `react-c3-component`.

```
ReferenceError: window is not defined
    at Object.<anonymous> (/Users/project/node_modules/c3/c3.js:7049:4)
```

It might due to the server side render problem in `c3.js` library.

## Solution

A workaround for this issue is to `require` the c3 library at componentDidMount phrase.
So the c3 library will invoke once only on the client (not on the server).