### PR TITLE
feat: use PureComponent [BREAKING CHANGE]

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "c3": "^0.4.0",
-    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
+    "react": "^15.3.0 || ^16.0.0"
   },
   "jest": {
     "coverageDirectory": "./coverage/",

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import c3 from 'c3';
 
-export default class Chart extends React.Component {
+export default class Chart extends React.PureComponent {
   static propTypes = {
     config: PropTypes.object,
   };
 
   componentDidMount() {
-    this.c3 = require('c3');
     this.generateChart();
   }
 
@@ -20,7 +20,7 @@ export default class Chart extends React.Component {
   }
 
   generateChart() {
-    this.chart = this.c3.generate({
+    this.chart = c3.generate({
       bindto: this.node,
       ...this.props.config,
     });


### PR DESCRIPTION
Use `PureComponent` to avoid unnecessary updates. This will need consumers to use react 15.3 or above. 